### PR TITLE
Use DART_SDK instead of DART_HOME in error msg

### DIFF
--- a/src/main/scala/com/typesafe/sbt/dart/DartSdk.scala
+++ b/src/main/scala/com/typesafe/sbt/dart/DartSdk.scala
@@ -17,7 +17,7 @@ object DartSdk {
 
     val DART_SDK = System.getenv("DART_SDK")
     if (DART_SDK == null) {
-      sys.error("DART_HOME env variable must be defined!")
+      sys.error("DART_SDK env variable must be defined!")
     } else {
       val dartHome = new File(DART_SDK)
       if (dartHome.exists())


### PR DESCRIPTION
As you call System.getenv("DART_SDK") I think you should display DART_SDK instead of DART_HOME in the error message
